### PR TITLE
DE47367 Only apply toast count limit to toasts which are rendered

### DIFF
--- a/src/ToastEvent.js
+++ b/src/ToastEvent.js
@@ -42,6 +42,13 @@ class ToastEvent {
   }
 
   get description() {
+    if (!this._isRendered) {
+      this._isRendered = true;
+      this._killTimeout = setTimeout(() => {
+        this._remove();
+      }, 4000);
+    }
+
     return this._description;
   }
 

--- a/src/ToastEvent.js
+++ b/src/ToastEvent.js
@@ -31,23 +31,13 @@ class ToastEvent {
   }
 
   get message() {
-    if (!this._isRendered) {
-      this._isRendered = true;
-      this._killTimeout = setTimeout(() => {
-        this._remove();
-      }, 4000);
-    }
+    this._setKillTimeout();
 
     return this._message;
   }
 
   get description() {
-    if (!this._isRendered) {
-      this._isRendered = true;
-      this._killTimeout = setTimeout(() => {
-        this._remove();
-      }, 4000);
-    }
+    this._setKillTimeout();
 
     return this._description;
   }
@@ -78,6 +68,15 @@ class ToastEvent {
       }, 300);
     }
     this.closing = true;
+  }
+
+  _setKillTimeout() {
+    if (!this._isRendered) {
+      this._isRendered = true;
+      this._killTimeout = setTimeout(() => {
+        this._remove();
+      }, 4000);
+    }
   }
 }
 

--- a/src/Toaster.js
+++ b/src/Toaster.js
@@ -111,10 +111,10 @@ class Toaster extends RtlMixin(LitElement) {
     let newEvents = [...this._events];
     newEvents.push(detail);
     this._events = newEvents;
-    // check if this event overflows the limit
-    if (this._events.length > this.limit) {
+    // check if this event overflows the limit -- only apply limit to visible elements
+    if (this._events.filter(e => e.visible).length > this.limit) {
       this._events.forEach((e, i) => {
-        if (i < this._events.length - this.limit) {
+        if (i < this._events.length - this.limit && e.visible) {
           e.markForRemoval();
         }
       });


### PR DESCRIPTION
There are accessibility toastEvents dispatched in the Assessment Quality dashboard which are not visible and don't get removed anywhere. They still contribute to the limit for the maximum number of toasts that should show up, so when there is a filter change, the number of toasts is over the limit and the filter change events get removed. As a result, the toast for updated filter doesn't show up long enough. See: [DE47367](https://rally1.rallydev.com/#/?detail=/defect/627370500519&fdp=true)

- Functional Testing
  -  Reproduce bug with local BSI on draco and in demo and verify that the code changes fix the issue, i.e. the toasts stay up for 3 seconds before getting removed
- Performance/Security/DevOps/Cost/Documentation/UX
  - n/a