### PR TITLE
fix: lit dependencies

### DIFF
--- a/demo/demo-view.js
+++ b/demo/demo-view.js
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit-element';
+import { LitElement, html } from 'lit';
 import { ToastEvent } from '../index.js';
 
 function parseHash(hash) {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "dependencies": {
     "@brightspace-ui/core": "^2",
-    "lit-element": "^3",
-    "lit-html": "^2"
+    "lit": "^2"
   },
   "devDependencies": {
     "@open-wc/eslint-config": "^4.3.0",

--- a/src/Toaster.js
+++ b/src/Toaster.js
@@ -1,7 +1,6 @@
-import { classMap } from 'lit-html/directives/class-map.js';
-import { LitElement, html, css } from 'lit-element';
-import { repeat } from 'lit-html/directives/repeat.js';
-import { nothing } from 'lit-html';
+import { classMap } from 'lit/directives/class-map.js';
+import { LitElement, html, css, nothing } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import ToastEvent from './ToastEvent.js';
 import '@brightspace-ui/core/components/alert/alert-toast';


### PR DESCRIPTION
This isn't a prerequisite for upgrading to Lit 3 next year, but cleaning up the warnings would be nice. Both `lit-element` and `lit-html` have been rolled into `lit` for quite some time.